### PR TITLE
Readline interface

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -96,6 +96,7 @@
     "mitt": "^1.1.2",
     "mkdirp": "^0.5.1",
     "moment": "^2.21.0",
+    "mute-stream": "^0.0.8",
     "name-all-modules-plugin": "^1.0.1",
     "normalize-path": "^2.1.1",
     "null-loader": "^0.1.1",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -111,6 +111,7 @@
     "react-dev-utils": "^4.2.3",
     "react-error-overlay": "^3.0.0",
     "react-hot-loader": "^4.12.11",
+    "readline-sync": "^1.4.10",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "semver": "^5.6.0",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -112,7 +112,6 @@
     "react-dev-utils": "^4.2.3",
     "react-error-overlay": "^3.0.0",
     "react-hot-loader": "^4.12.11",
-    "readline-sync": "^1.4.10",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "semver": "^5.6.0",

--- a/packages/gatsby/src/commands/develop.js
+++ b/packages/gatsby/src/commands/develop.js
@@ -12,7 +12,6 @@ const graphqlPlayground = require(`graphql-playground-middleware-express`)
 const graphiqlExplorer = require(`gatsby-graphiql-explorer`)
 const { formatError } = require(`graphql`)
 const got = require(`got`)
-const rl = require(`readline`)
 const webpack = require(`webpack`)
 const webpackConfig = require(`../utils/webpack.config`)
 const bootstrap = require(`../bootstrap`)
@@ -52,20 +51,6 @@ const requiresWriter = require(`../bootstrap/requires-writer`)
 setTimeout(() => {
   syncStaticDir()
 }, 10000)
-
-const rlInterface = rl.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-})
-
-// Quit immediately on hearing ctrl-c
-rlInterface.on(`close`, () => {
-  // fixes issue with bash shell not receiving control of
-  // stdio when exiting
-  rlInterface.close() // Release stdio streams
-  process.kill(process.pid, `SIGINT`) // Relay signal to node
-  process.kill(process.ppid, `SIGINT`) // Relay signal to parent process (/bin/sh)
-})
 
 onExit(() => {
   telemetry.trackCli(`DEVELOP_STOP`)
@@ -334,6 +319,23 @@ module.exports = async (program: any) => {
     )
   }
 
+  try {
+    program.port = await detectPortInUseAndPrompt(port)
+  } catch (e) {
+    switch (e) {
+      case `USER_REJECTED`: {
+        // If port was already taken, and user said don't pick new
+        // port, then exit the process
+        process.exit(0)
+        break
+      }
+      default: {
+        // Unknown exception occurred.  Rethrow error
+        throw e
+      }
+    }
+  }
+
   // Check if https is enabled, then create or get SSL cert.
   // Certs are named after `name` inside the project's package.json.
   // Scoped names are converted from @npm/package-name to npm--package-name
@@ -346,7 +348,6 @@ module.exports = async (program: any) => {
     })
   }
 
-  program.port = await detectPortInUseAndPrompt(port, rlInterface)
   // Start bootstrap process.
   const { graphqlRunner } = await bootstrap(program)
 

--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
@@ -1,21 +1,38 @@
 const detectPort = require(`detect-port`)
 const report = require(`gatsby-cli/lib/reporter`)
+// const prompt = require(`./readline-interface`).prompt
+const readlineSync = require(`readline-sync`)
 
-const readlinePort = (port, rlInterface) => {
+const readlinePort = port => {
   const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n] `
   return new Promise(resolve => {
-    rlInterface.question(question, answer => {
-      resolve(answer.length === 0 || answer.match(/^yes|y$/i))
+    // prompt.once(question, answer => {
+    //   resolve(answer.length === 0 || answer.match(/^yes|y$/i))
+    // })
+    const interrupt = () => {
+      process.exit(0)
+    }
+    process.on(`SIGINT`, interrupt)
+    const answer = readlineSync.keyIn(question, {
+      limit: [`y`, `n`, ``],
+      defaultInput: `y`,
+      caseSensitive: false,
+      trueValue: [`y`],
+      falseValue: [`n`],
     })
+    process.removeListener(`SIGINT`, interrupt)
+    resolve(answer)
   })
 }
 
-const detectPortInUseAndPrompt = async (port, rlInterface) => {
+const detectPortInUseAndPrompt = async port => {
   let foundPort = port
   const detectedPort = await detectPort(port).catch(err => report.panic(err))
   if (port !== detectedPort) {
-    if (await readlinePort(port, rlInterface)) {
+    if (await readlinePort(port)) {
       foundPort = detectedPort
+    } else {
+      return Promise.reject(`USER_REJECTED`)
     }
   }
   return foundPort

--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
@@ -11,7 +11,7 @@ const readlinePort = port => {
         resolve(answer)
       },
       {
-        single: false,
+        single: true,
         validInput: [`Y`, `n`],
         defaultValue: `y`,
         returnBoolean: {

--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
@@ -1,27 +1,27 @@
 const detectPort = require(`detect-port`)
 const report = require(`gatsby-cli/lib/reporter`)
-// const prompt = require(`./readline-interface`).prompt
-const readlineSync = require(`readline-sync`)
+const prompt = require(`./readline-interface`).prompt
+// const readlineSync = require(`readline-sync`)
 
 const readlinePort = port => {
   const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n] `
   return new Promise(resolve => {
-    // prompt.once(question, answer => {
-    //   resolve(answer.length === 0 || answer.match(/^yes|y$/i))
-    // })
-    const interrupt = () => {
-      process.exit(0)
-    }
-    process.on(`SIGINT`, interrupt)
-    const answer = readlineSync.keyIn(question, {
-      limit: [`y`, `n`, ``],
-      defaultInput: `y`,
-      caseSensitive: false,
-      trueValue: [`y`],
-      falseValue: [`n`],
+    prompt.once(question, answer => {
+      resolve(answer.length === 0 || answer.match(/^yes|y$/i))
     })
-    process.removeListener(`SIGINT`, interrupt)
-    resolve(answer)
+    // const interrupt = () => {
+    //   process.exit(0)
+    // }
+    // process.on(`SIGINT`, interrupt)
+    // const answer = readlineSync.keyIn(question, {
+    //   limit: [`y`, `n`, ``],
+    //   defaultInput: `y`,
+    //   caseSensitive: false,
+    //   trueValue: [`y`],
+    //   falseValue: [`n`],
+    // })
+    // process.removeListener(`SIGINT`, interrupt)
+    // resolve(answer)
   })
 }
 

--- a/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
+++ b/packages/gatsby/src/utils/detect-port-in-use-and-prompt.js
@@ -1,27 +1,24 @@
 const detectPort = require(`detect-port`)
 const report = require(`gatsby-cli/lib/reporter`)
-const prompt = require(`./readline-interface`).prompt
-// const readlineSync = require(`readline-sync`)
+const { prompt } = require(`./readline-interface`)
 
 const readlinePort = port => {
-  const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n] `
+  const question = `Something is already running at port ${port} \nWould you like to run the app at another port instead? [Y/n]: `
   return new Promise(resolve => {
-    prompt.once(question, answer => {
-      resolve(answer.length === 0 || answer.match(/^yes|y$/i))
-    })
-    // const interrupt = () => {
-    //   process.exit(0)
-    // }
-    // process.on(`SIGINT`, interrupt)
-    // const answer = readlineSync.keyIn(question, {
-    //   limit: [`y`, `n`, ``],
-    //   defaultInput: `y`,
-    //   caseSensitive: false,
-    //   trueValue: [`y`],
-    //   falseValue: [`n`],
-    // })
-    // process.removeListener(`SIGINT`, interrupt)
-    // resolve(answer)
+    prompt.once(
+      question,
+      answer => {
+        resolve(answer)
+      },
+      {
+        single: false,
+        validInput: [`Y`, `n`],
+        defaultValue: `y`,
+        returnBoolean: {
+          trueValue: `y`,
+        },
+      }
+    )
   })
 }
 

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -1,0 +1,118 @@
+// /* @flow */
+// const readline = require(`readline`)
+
+// type ReadlineOptions = {
+//   input: NodeJS.ReadStream,
+//   output: NodeJS.WriteStream,
+//   terminal: boolean,
+//   historySize: ?number,
+//   prompt: ?string,
+//   crlfDelay: ?number,
+//   removeHistoryDuplicates: ?boolean,
+//   escapeCodeTimeout: ?number,
+// }
+
+// const defaultIntfcOpts: ReadlineOptions = {
+//   input: process.stdin,
+//   output: process.stdout,
+//   terminal: true,
+// }
+
+// /**
+//  * Spins up and returns a readline interface
+//  * @param {ReadlineOptions} opts
+//  */
+// function create(opts: ?ReadlineOptions) {
+//   const rlOpts = {
+//     ...defaultIntfcOpts,
+//     ...opts,
+//   }
+
+//   const stdin = rlOpts.input
+//   const stdout = rlOpts.output
+
+//   if (!stdin || (stdin !== process.stdin && !stdin.isTTY)) {
+//     throw new Error(`Invalid stream passed`)
+//   }
+//   if (!stdout || (stdout !== process.stdout && !stdout.isTTY)) {
+//     throw new Error(`Invalid output passed`)
+//   }
+
+//   const rl = readline.createInterface({
+//     ...defaultIntfcOpts,
+//     ...opts,
+//   })
+
+//   const isRaw = stdin.isRaw
+//   if (stdin.isTTY) stdin.setRawMode(true)
+
+//   // Save a reference to the original
+//   // close function, so we can call it later
+//   const rlClose = rl.close
+
+//   const close = () => {
+//     if (stdin.isTTY) stdin.setRawMode(isRaw)
+//     rl.pause()
+//     rlClose()
+//   }
+//   // Overloading the close interface, so we
+//   // can inject some custom behavior
+//   rl.close = close
+
+//   // rl.resume()
+
+//   return rl
+// }
+
+// // const ask = rl => (query: any, cb: (answer: any) => void) => {
+// //   rl.setPrompt(query)
+// //   rl.prompt()
+// //   rl.on(`line`, input => {
+// //     cb(input.trim())
+// //   })
+// // }
+
+// const prompt = {
+//   /**
+//    * Create a new readline dedicated to providing the question
+//    * interface
+//    * @param {ReadlineOptions} rlOpts Options to override readline interface
+//    * with
+//    */
+//   new: async (rlOpts: ?ReadlineOptions) => {
+//     const rl = create(rlOpts)
+//     return {
+//       // ask: ask(rl),
+//       ask: rl.question,
+//       done: rl.close,
+//     }
+//   },
+//   /**
+//    * Creates a new readline interface for a one-time prompt, then closes it.
+//    * @param {string} query The question to ask the user
+//    * @param {(answer: any) => void} cb The callback that will receive the user's
+//    * input
+//    * @param {ReadlineOptions} rlOpts Options to override the readline interface
+//    */
+//   once: (
+//     query: string,
+//     cb: (answer: any) => void,
+//     rlOpts: ?ReadlineOptions
+//   ) => {
+//     const rl = create(rlOpts)
+//     rl.question(query, answer => {
+//       rl.close()
+//       cb(answer)
+//     })
+//     // ask(rl)(query, answer => {
+//     //   cb(answer)
+//     //   rl.close()
+//     // })
+//   },
+// }
+
+// module.exports = {
+//   create,
+//   prompt,
+//   // extend features here
+// }

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -244,7 +244,7 @@ const prompt = {
    * @param {ReadlineOptions} rlOpts Options to override readline interface
    * with
    */
-  new: async (rlOpts: ?ReadlineOptions) => {
+  new: (rlOpts: ?ReadlineOptions) => {
     const [rl, done] = create(rlOpts)
     return {
       ask: ask(rl),

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -1,118 +1,118 @@
-// /* @flow */
-// const readline = require(`readline`)
+/* @flow */
+const readline = require(`readline`)
 
-// type ReadlineOptions = {
-//   input: NodeJS.ReadStream,
-//   output: NodeJS.WriteStream,
-//   terminal: boolean,
-//   historySize: ?number,
-//   prompt: ?string,
-//   crlfDelay: ?number,
-//   removeHistoryDuplicates: ?boolean,
-//   escapeCodeTimeout: ?number,
-// }
+type ReadlineOptions = {
+  input: NodeJS.ReadStream,
+  output: NodeJS.WriteStream,
+  terminal: boolean,
+  historySize: ?number,
+  prompt: ?string,
+  crlfDelay: ?number,
+  removeHistoryDuplicates: ?boolean,
+  escapeCodeTimeout: ?number,
+}
 
-// const defaultIntfcOpts: ReadlineOptions = {
-//   input: process.stdin,
-//   output: process.stdout,
-//   terminal: true,
-// }
+const defaultIntfcOpts: ReadlineOptions = {
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false,
+}
 
-// /**
-//  * Spins up and returns a readline interface
-//  * @param {ReadlineOptions} opts
-//  */
-// function create(opts: ?ReadlineOptions) {
-//   const rlOpts = {
-//     ...defaultIntfcOpts,
-//     ...opts,
-//   }
+/**
+ * Spins up and returns a readline interface
+ * @param {ReadlineOptions} opts
+ */
+function create(opts: ?ReadlineOptions) {
+  const rlOpts = {
+    ...defaultIntfcOpts,
+    ...opts,
+  }
 
-//   const stdin = rlOpts.input
-//   const stdout = rlOpts.output
+  const stdin = rlOpts.input
+  const stdout = rlOpts.output
 
-//   if (!stdin || (stdin !== process.stdin && !stdin.isTTY)) {
-//     throw new Error(`Invalid stream passed`)
-//   }
-//   if (!stdout || (stdout !== process.stdout && !stdout.isTTY)) {
-//     throw new Error(`Invalid output passed`)
-//   }
+  if (!stdin || (stdin !== process.stdin && !stdin.isTTY)) {
+    throw new Error(`Invalid stream passed`)
+  }
+  if (!stdout || (stdout !== process.stdout && !stdout.isTTY)) {
+    throw new Error(`Invalid output passed`)
+  }
 
-//   const rl = readline.createInterface({
-//     ...defaultIntfcOpts,
-//     ...opts,
+  const rl = readline.createInterface({
+    ...defaultIntfcOpts,
+    ...opts,
+  })
+
+  // const isRaw = stdin.isRaw
+  // if (stdin.isTTY) stdin.setRawMode(true)
+
+  // Save a reference to the original
+  // close function, so we can call it later
+  const rlClose = rl.close
+
+  const close = () => {
+    // if (stdin.isTTY) stdin.setRawMode(isRaw)
+    rl.pause()
+    rlClose()
+  }
+  // Overloading the close interface, so we
+  // can inject some custom behavior
+  rl.close = close
+
+  // rl.resume()
+
+  return rl
+}
+
+// const ask = rl => (query: any, cb: (answer: any) => void) => {
+//   rl.setPrompt(query)
+//   rl.prompt()
+//   rl.on(`line`, input => {
+//     cb(input.trim())
 //   })
-
-//   const isRaw = stdin.isRaw
-//   if (stdin.isTTY) stdin.setRawMode(true)
-
-//   // Save a reference to the original
-//   // close function, so we can call it later
-//   const rlClose = rl.close
-
-//   const close = () => {
-//     if (stdin.isTTY) stdin.setRawMode(isRaw)
-//     rl.pause()
-//     rlClose()
-//   }
-//   // Overloading the close interface, so we
-//   // can inject some custom behavior
-//   rl.close = close
-
-//   // rl.resume()
-
-//   return rl
 // }
 
-// // const ask = rl => (query: any, cb: (answer: any) => void) => {
-// //   rl.setPrompt(query)
-// //   rl.prompt()
-// //   rl.on(`line`, input => {
-// //     cb(input.trim())
-// //   })
-// // }
+const prompt = {
+  /**
+   * Create a new readline dedicated to providing the question
+   * interface
+   * @param {ReadlineOptions} rlOpts Options to override readline interface
+   * with
+   */
+  new: async (rlOpts: ?ReadlineOptions) => {
+    const rl = create(rlOpts)
+    return {
+      // ask: ask(rl),
+      ask: rl.question,
+      done: rl.close,
+    }
+  },
+  /**
+   * Creates a new readline interface for a one-time prompt, then closes it.
+   * @param {string} query The question to ask the user
+   * @param {(answer: any) => void} cb The callback that will receive the user's
+   * input
+   * @param {ReadlineOptions} rlOpts Options to override the readline interface
+   */
+  once: (
+    query: string,
+    cb: (answer: any) => void,
+    rlOpts: ?ReadlineOptions
+  ) => {
+    const rl = create(rlOpts)
+    rl.question(query, answer => {
+      rl.close()
+      cb(answer)
+    })
+    // ask(rl)(query, answer => {
+    //   cb(answer)
+    //   rl.close()
+    // })
+  },
+}
 
-// const prompt = {
-//   /**
-//    * Create a new readline dedicated to providing the question
-//    * interface
-//    * @param {ReadlineOptions} rlOpts Options to override readline interface
-//    * with
-//    */
-//   new: async (rlOpts: ?ReadlineOptions) => {
-//     const rl = create(rlOpts)
-//     return {
-//       // ask: ask(rl),
-//       ask: rl.question,
-//       done: rl.close,
-//     }
-//   },
-//   /**
-//    * Creates a new readline interface for a one-time prompt, then closes it.
-//    * @param {string} query The question to ask the user
-//    * @param {(answer: any) => void} cb The callback that will receive the user's
-//    * input
-//    * @param {ReadlineOptions} rlOpts Options to override the readline interface
-//    */
-//   once: (
-//     query: string,
-//     cb: (answer: any) => void,
-//     rlOpts: ?ReadlineOptions
-//   ) => {
-//     const rl = create(rlOpts)
-//     rl.question(query, answer => {
-//       rl.close()
-//       cb(answer)
-//     })
-//     // ask(rl)(query, answer => {
-//     //   cb(answer)
-//     //   rl.close()
-//     // })
-//   },
-// }
-
-// module.exports = {
-//   create,
-//   prompt,
-//   // extend features here
-// }
+module.exports = {
+  create,
+  prompt,
+  // extend features here
+}

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -147,7 +147,7 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
 }
 
 /**
- * This (internal) function will prompt the user with a specific question.
+ * This function will prompt the user with a specific question.
  * @param {readline.Interface} rl The readline interface to use for the prompts
  * @returns {(query, cb, askOpts: AskOptions) => void} Call this interface to generate the prompt
  * * `query`: The question to ask the user

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -35,7 +35,16 @@ type KeypressKey = {
 }
 
 type CanListen = "input"
-type ListenerTypes = "all" | "input"
+type ListenerTypes = "all" | "input" | "rl"
+
+type ListenerCache = {
+  rl: {
+    line: Function[],
+  },
+  input: {
+    keypress: Function[],
+  },
+}
 
 /**
  * Collection of various readline utility functions
@@ -93,8 +102,13 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
   const msOut = new MuteStream()
   const isRaw = stdin.isRaw
   const isTTY = stdin.isTTY
-  const listeners = {
-    input: {},
+  const listeners: ListenerCache = {
+    input: {
+      keypress: [],
+    },
+    rl: {
+      line: [],
+    },
   }
 
   const defaultPrompt = (opts && opts.prompt) || ``
@@ -230,7 +244,7 @@ const ask = (rl: readline.Interface) => (
 
   RlUtil.showCursor(rl)
 
-  const validateInput = (input): void => {
+  const validateInput = (input): boolean => {
     let good = true
     let answer = input.toString()
     let sensitivity = `i`
@@ -259,7 +273,7 @@ const ask = (rl: readline.Interface) => (
     return good
   }
 
-  const onKeypress = (chunk, key): void => {
+  const onKeypress = (chunk: string, key: KeypressKey): KeypressKey => {
     if (key.ctrl && key.name === `c`) {
       rl.emit(`SIGINT`)
     } else if (key.name === `return` && opts.single) {

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -100,7 +100,7 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
    * Call `done()` to break down the readline interface
    */
   const done = () => {
-    stdin.setRawMode(isRaw)
+    rl.setRaw(isRaw)
     rl.removeAllListeners()
     rl.pause()
     rl.close()
@@ -112,7 +112,7 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
   })
 
   rl.setRaw = (rawMode = true) => {
-    stdin.setRawMode(rawMode)
+    if (rl.input.isTTY) stdin.setRawMode(rawMode)
   }
 
   rl.listen = keypress => {
@@ -141,6 +141,8 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
     }
   }
 
+  rl.isTTY = () => rl.input.isTTY
+
   rl.resume()
 
   return [rl, done]
@@ -164,6 +166,9 @@ const ask = (rl: readline.Interface) => (
   cb: (answer: any) => void,
   askOpts: ?KeyInOptions = {}
 ) => {
+  if (askOpts && askOpts.single) {
+    if (!rl.isTTY) askOpts.single = false
+  }
   const opts: AskOpts = {
     single: false,
     ...askOpts,

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -132,6 +132,9 @@ const create = (opts: ?ReadlineOptions): [readline.Interface, () => void] => {
     if (rl.isTTY) stdin.setRawMode(rawMode)
   }
 
+  /**
+   * Listen for keypress events, to read each keystroke
+   */
   rl.listen = (keypress: (chunk: string, key: KeypressKey) => void) => {
     // Can only listen for keypress on tty input streams
     if (rl.isTTY) {

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -206,8 +206,7 @@ const ask = (rl: readline.Interface) => (
       if (opts.returnBoolean) {
         if (
           new RegExp(`^${answer}$`, sensitivity).test(
-            opts.returnBoolean.trueValue,
-            sensitivity
+            opts.returnBoolean.trueValue
           )
         ) {
           answer = true

--- a/packages/gatsby/src/utils/readline-interface.js
+++ b/packages/gatsby/src/utils/readline-interface.js
@@ -26,6 +26,14 @@ type AskOpts = {
   },
 }
 
+type KeypressKey = {
+  sequence: string,
+  name: string,
+  ctrl: boolean,
+  meta: boolean,
+  shift: boolean,
+}
+
 /**
  * Collection of various readline utility functions
  */
@@ -68,7 +76,9 @@ const RlUtil = {
 
 /**
  * Spins up and returns a readline interface, for tty IO ONLY!
- * Using this function will give you nearly a barebones readline interface
+ * Using this function will give you a nearly barebones readline interface
+ * It does, however, manage the IO streams for you, and provides some readline
+ * overloads for utility functions
  * @param {ReadlineOptions} opts Readline option overrides
  * @returns {[readline.Interface, done]} Returns a tuple containing the readline
  * interface, and the teardown method

--- a/yarn.lock
+++ b/yarn.lock
@@ -17579,6 +17579,11 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
 readline-sync@^1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.9.tgz#3eda8e65f23cd2a17e61301b1f0003396af5ecda"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14931,6 +14931,11 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+mute-stream@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 mv@2.1.1, mv@~2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17584,11 +17584,6 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readline-sync@^1.4.10:
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
-  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
-
 readline-sync@^1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.9.tgz#3eda8e65f23cd2a17e61301b1f0003396af5ecda"


### PR DESCRIPTION
## Description

Since `readline` is a "low-level" interface (as low-level as we generally get, anyway), it has a few different quirks.  It interfaces with stdio, and there are issues with closure, especially when other modules/processes want to use the stdio streams.

Because of this, there needs to be a layer of streams on top of the process stdio.  Since this adds significantly to the complexity of using a `readline` interface, this module creates an abstraction layer over the top, which will manage all of the details.

Since this is adding a layer of abstraction, I thought it would also be best to handle some of the use-cases for this module.  That's where the `prompt` export comes in.  It provides the capability to generate prompts, and collect input from the user, without the caller needing to worry about the streams.